### PR TITLE
Move splash page styling into a div

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -40,7 +40,7 @@
 
 
 
-.App {
+.SplashPage {
   font-family: 'Fredoka One', cursive;
   text-align: center;
   min-height: 100vh;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -175,8 +175,7 @@ class App extends Component {
       )
     } else {
       content = (
-        // <div className="authenticate">
-        <React.Fragment>
+        <div className="SplashPage">
             <div className="LoginDiv">
             <Login styles={styles} liftToken={this.liftTokenToState} liftMessage={this.liftMessageToState} />
             </div>
@@ -187,8 +186,7 @@ class App extends Component {
             <Signup styles={styles} liftToken={this.liftTokenToState} liftMessage={this.liftMessageToState} />
             <h3>{ this.state.message }</h3> 
             </div>
-            </React.Fragment>
-        // </div>
+        </div>
       )
     }
     return (


### PR DESCRIPTION
The styling on the .App div is getting applied to all later divs.

Moving the login and other components from the splash page into a div with the styling applied will help separate the styling for each page.

What do you think?